### PR TITLE
Updating the LB SSL security policy 

### DIFF
--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -73,7 +73,7 @@ resource "aws_lb_listener" "www_ssl_lb_listener" {
   load_balancer_arn = aws_lb.www_lb.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   certificate_arn   = data.aws_acm_certificate.www_certificate.arn
 
   default_action {


### PR DESCRIPTION
Using what I've seen as the current standard for what protocols to accept. 

[AWS Docs on this](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html)