### PR TITLE
TECH-505: Separate vpc to module for reusability

### DIFF
--- a/app/vpc.tf
+++ b/app/vpc.tf
@@ -1,26 +1,18 @@
 locals {
-  subnet = "${terraform.workspace == "production" ? 20 : 10}"
+  subnet = {
+    # Add your terraform workspaces and associated subnet here
+    "production" = 20
+    "dev"        = 10
+  }
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source               = "../modules/vpc/"
+  name                 = "nerves-hub-${terraform.workspace}"
+  subnet               = local.subnet
+  enable_dhcp_options  = true
+  enable_dns_hostnames = true
 
-  name = "nerves-hub-${terraform.workspace}"
-
-  cidr = "10.${local.subnet}.0.0/16"
-
-  azs                 = ["us-east-1a", "us-east-1b"]
-  private_subnets     = ["10.${local.subnet}.1.0/24", "10.${local.subnet}.2.0/24"]
-  public_subnets      = ["10.${local.subnet}.11.0/24", "10.${local.subnet}.12.0/24"]
-  database_subnets    = ["10.${local.subnet}.21.0/24", "10.${local.subnet}.22.0/24"]
-
-  create_database_subnet_group = true
-  enable_nat_gateway           = true
-  enable_vpn_gateway           = false
-  enable_s3_endpoint           = false
-  enable_dhcp_options          = true
-  enable_dns_hostnames         = true
-  enable_dns_support           = true
   tags = {
     Owner       =  "nerves-hub-${terraform.workspace}"
     Environment = "${terraform.workspace}"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,27 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.63"
+
+  name = "${var.app_name}-${terraform.workspace}-vpc"
+  cidr = "10.${var.subnet[terraform.workspace]}.0.0/16"
+
+  azs                 = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets     = ["10.${var.subnet[terraform.workspace]}.1.0/24", "10.${var.subnet[terraform.workspace]}.2.0/24"]
+  public_subnets      = ["10.${var.subnet[terraform.workspace]}.11.0/24", "10.${var.subnet[terraform.workspace]}.12.0/24"]
+  database_subnets    = ["10.${var.subnet[terraform.workspace]}.21.0/24", "10.${var.subnet[terraform.workspace]}.22.0/24"]
+
+  create_database_subnet_group     = var.create_database_subnet_group
+  enable_nat_gateway               = var.enable_nat_gateway
+  single_nat_gateway               = var.single_nat_gateway
+  enable_vpn_gateway               = var.enable_vpn_gateway
+  enable_s3_endpoint               = var.enable_s3_endpoint
+  enable_dhcp_options              = var.enable_dhcp_options
+  enable_dns_hostnames             = var.enable_dns_hostnames
+  enable_dns_support               = var.enable_dns_support
+  one_nat_gateway_per_az           = var.one_nat_gateway_per_az
+  manage_default_vpc               = var.manage_default_vpc
+  default_vpc_name                 = "${var.app_name}-${terraform.workspace}-default-vpc"
+  default_vpc_enable_dns_hostnames = var.default_vpc_enable_dns_hostnames
+
+  tags = var.tags
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 2.63"
 
-  name = "${var.app_name}-${terraform.workspace}-vpc"
+  name = var.name
   cidr = "10.${var.subnet[terraform.workspace]}.0.0/16"
 
   azs                 = ["us-east-1a", "us-east-1b", "us-east-1c"]
@@ -20,7 +20,7 @@ module "vpc" {
   enable_dns_support               = var.enable_dns_support
   one_nat_gateway_per_az           = var.one_nat_gateway_per_az
   manage_default_vpc               = var.manage_default_vpc
-  default_vpc_name                 = "${var.app_name}-${terraform.workspace}-default-vpc"
+  default_vpc_name                 = "${var.name}-default-vpc"
   default_vpc_enable_dns_hostnames = var.default_vpc_enable_dns_hostnames
 
   tags = var.tags

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "cidr_block" {
+  value = module.vpc.vpc_cidr_block
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -6,7 +6,7 @@ variable "tags" {
   }
 }
 
-variable "app_name" {
+variable "name" {
   description = "The application name"
   type        = string
   default     = "nerves-hub"

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,79 @@
+variable "tags" {
+  description = "A mapping of tags to assign to the resources"
+  type        = map(string)
+  default = {
+    terraform = true
+  }
+}
+
+variable "app_name" {
+  description = "The application name"
+  type        = string
+  default     = "nerves-hub"
+}
+
+variable "subnet" {
+  description = ""
+  type = map(string)
+}
+
+variable "create_database_subnet_group" {
+  type    = bool
+  default = true
+}
+
+variable "enable_nat_gateway" {
+  type    = bool
+  default = true
+}
+
+variable "single_nat_gateway" {
+  type    = bool
+  default = false
+}
+
+variable "enable_vpn_gateway" {
+  type    = bool
+  default = false
+}
+
+variable "enable_s3_endpoint" {
+  type    = bool
+  default = false
+}
+
+variable "enable_dhcp_options" {
+  type    = bool
+  default = false
+}
+
+variable "enable_dns_hostnames" {
+  type    = bool
+  default = false
+}
+
+variable "enable_dns_support" {
+  type    = bool
+  default = true
+}
+
+variable "one_nat_gateway_per_az" {
+  type    = bool
+  default = false
+}
+
+variable "manage_default_vpc" {
+  type    = bool
+  default = false
+}
+
+variable "default_vpc_name" {
+  type    = string
+  default = ""
+}
+
+variable "default_vpc_enable_dns_hostnames" {
+  type    = bool
+  default = false
+}
+


### PR DESCRIPTION
## Description 

Create a separate VPC module to allow for reusability with more than two environments and allows flexibility with configuration options. 
- mapping the subnets to certain environments 
- move vpc to a separate module while keeping repo specific configs in app/vpc.tf (and any non-default parameters)
- kept parameters from original app/vpc.tf and added parameters that may be different for our use case
- included defaults for those parameters (original to the terraform-aws-modules/vpc/aws module)
- added outputs that are useful or used by other modules
- added the current latest version for the terraform-aws-modules/vpc/aws 

Thoughts on having this vpc module separate here? This would allow more flexibility here I think. But open to thoughts. 