### PR TITLE
Fix variable names in tfvars.example

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -2,8 +2,8 @@
 ## AWS
 ##
 
-aws_region = "us-east-1"
-aws_profile = "nerves-hub"
+region = "us-east-1"
+profile = "nerves-hub"
 
 ##
 ## Terraform


### PR DESCRIPTION
The terraform scripts actually expect the variables to not have the aws prefix, which leads to a bunch of errors when running setup.sh.