### PR TITLE
Fix smtp username/password mixup

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -165,14 +165,14 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_ses_server" {
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_smtp_username" {
   name      = "/${local.app_name}/${terraform.workspace}/SMTP_USERNAME"
   type      = "SecureString"
-  value     = var.smtp_password
+  value     = var.smtp_username
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_smtp_password" {
   name      = "/${local.app_name}/${terraform.workspace}/SMTP_PASSWORD"
   type      = "SecureString"
-  value     = var.smtp_username
+  value     = var.smtp_password
   overwrite = true
 }
 

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -159,14 +159,14 @@ resource "aws_ssm_parameter" "nerves_hub_device_ssm_ses_server" {
 resource "aws_ssm_parameter" "nerves_hub_device_ssm_smtp_username" {
   name      = "/${local.device_app_name}/${terraform.workspace}/SMTP_USERNAME"
   type      = "SecureString"
-  value     = var.smtp_password
+  value     = var.smtp_username
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "nerves_hub_device_ssm_secret_smtp_password" {
   name      = "/${local.device_app_name}/${terraform.workspace}/SMTP_PASSWORD"
   type      = "SecureString"
-  value     = var.smtp_username
+  value     = var.smtp_password
   overwrite = true
 }
 

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -184,14 +184,14 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_server" {
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_smtp_username" {
   name      = "/nerves_hub_www/${terraform.workspace}/SMTP_USERNAME"
   type      = "SecureString"
-  value     = var.smtp_password
+  value     = var.smtp_username
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_smtp_password" {
   name      = "/nerves_hub_www/${terraform.workspace}/SMTP_PASSWORD"
   type      = "SecureString"
-  value     = var.smtp_username
+  value     = var.smtp_password
   overwrite = true
 }
 


### PR DESCRIPTION
This PR fixes a mistake in which the smtp username and password values were reversed. 